### PR TITLE
fix: Catch multiple leak occurrences in same string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ env/
 venv/
 /site
 .idea/
+.DS_Store

--- a/maskerlogger/__init__.py
+++ b/maskerlogger/__init__.py
@@ -1,5 +1,7 @@
 """
 Init file for oxformatter package.
 """
-from maskerlogger.masker_formatter import MaskerFormatter, MaskerFormatterJson # noqa
-__version__ = '0.4.0-beta.1'
+
+from maskerlogger.masker_formatter import MaskerFormatter, MaskerFormatterJson  # noqa
+
+__version__ = "0.4.0-beta.1"

--- a/maskerlogger/__init__.py
+++ b/maskerlogger/__init__.py
@@ -2,6 +2,17 @@
 Init file for oxformatter package.
 """
 
-from maskerlogger.masker_formatter import MaskerFormatter, MaskerFormatterJson  # noqa
+from maskerlogger.masker_formatter import (
+    MaskerFormatter,
+    MaskerFormatterJson,
+    mask_string,
+)
+
+# Expose the classes and main function
+__all__ = [
+    "MaskerFormatter",
+    "MaskerFormatterJson",
+    "mask_string",
+]
 
 __version__ = "0.4.0-beta.1"

--- a/maskerlogger/ahocorasick_regex_match.py
+++ b/maskerlogger/ahocorasick_regex_match.py
@@ -3,6 +3,7 @@ import re
 from typing import List
 import ahocorasick
 from maskerlogger.utils import timeout
+from collections import defaultdict
 
 
 MAX_MATCH_TIMEOUT = 1
@@ -19,47 +20,57 @@ class RegexMatcher:
         for keyword, regexs in self.keyword_to_patterns.items():
             keyword_automaton.add_word(keyword, (regexs))
         keyword_automaton.make_automaton()
+
         return keyword_automaton
 
     @staticmethod
     def _load_config(config_path: str) -> dict:
-        with open(config_path, 'rb') as f:
+        with open(config_path, "rb") as f:
             return toml.load(f)
 
-    def _extract_keywords_and_patterns(self, config) -> dict:
-        keyword_to_patterns = {}
-        for rule in config['rules']:
-            for keyword in rule.get('keywords', []):
-                if keyword not in keyword_to_patterns:
-                    keyword_to_patterns[keyword] = []
+    def _extract_keywords_and_patterns(
+        self, config: dict
+    ) -> dict[str, List[re.Pattern]]:
+        """Extracts keywords and their corresponding regex patterns from the configuration file."""
+        keyword_to_patterns = defaultdict(list)
 
-                keyword_to_patterns[keyword].append(self._get_compiled_regex(
-                    rule['regex']))
+        for rule in config["rules"]:
+            for keyword in rule.get("keywords", []):
+                keyword_to_patterns[keyword].append(
+                    self._get_compiled_regex(rule["regex"])
+                )
 
-        return keyword_to_patterns
+        return dict(keyword_to_patterns)
 
-    def _get_compiled_regex(self, regex: str) -> str:
-        if '(?i)' in regex:
-            regex = regex.replace('(?i)', '')
+    def _get_compiled_regex(self, regex: str) -> re.Pattern[str]:
+        """Compiles the regex pattern and returns the compiled pattern."""
+        if "(?i)" in regex:
+            regex = regex.replace("(?i)", "")
             return re.compile(regex, re.IGNORECASE)
         return re.compile(regex)
 
-    def _filter_by_keywords(self, line):
+    def _filter_by_keywords(self, line: str) -> list[re.Pattern[str]]:
+        """Filters the regex patterns based on the keywords present in the line."""
+
         matched_regexes = set()
-        for end_index, regex_values in self.automaton.iter(line):
+        for _, regex_values in self.automaton.iter(line):
             matched_regexes.update(regex_values)
-        return matched_regexes
+
+        return list(matched_regexes)
 
     @timeout(MAX_MATCH_TIMEOUT)
-    def _get_match_regex(self, line: str,
-                         matched_regex: List[re.Pattern]) -> List[re.Match]:
-        matches = []
-        for regex in matched_regex:
-            if match := regex.search(line):
-                matches.append(match)
-        return matches
+    def _get_match_regex(
+        self,
+        line: str,
+        matched_regex: List[re.Pattern[str]],
+    ) -> List[re.Match]:
+        """Gets the matches of the regex patterns in the given line."""
+        return [match for regex in matched_regex for match in regex.finditer(line)]
 
-    def match_regex_to_line(self, line: str) -> re.Match:
+    def match_regex_to_line(self, line: str) -> list[re.Match[str]]:
+        """Matches the regex patterns to the given line."""
         lower_case_line = line.lower()
-        if matched_regxes := self._filter_by_keywords(lower_case_line):
-            return self._get_match_regex(line, matched_regxes)
+
+        if matched_regexes := self._filter_by_keywords(lower_case_line):
+            return self._get_match_regex(line, matched_regexes)
+        return []

--- a/maskerlogger/config/gitleaks.toml
+++ b/maskerlogger/config/gitleaks.toml
@@ -505,7 +505,7 @@ keywords = [
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-zA-Z\-_.!$&'*+/=?^_`{|}~#@,;:]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-zA-Z\-_.!$&'*+/=?^_`{|}~#@,;:%^]{8,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = [
     "key","api","token","secret","client","passwd","password","auth","access",

--- a/maskerlogger/config/gitleaks.toml
+++ b/maskerlogger/config/gitleaks.toml
@@ -505,7 +505,7 @@ keywords = [
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-zA-Z\-_.!$&'*+/=?^_`{|}~#@,;:]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = [
     "key","api","token","secret","client","passwd","password","auth","access",

--- a/maskerlogger/secrets_in_logs_example.py
+++ b/maskerlogger/secrets_in_logs_example.py
@@ -10,19 +10,21 @@ def main():
     """
     Main function to demonstrate logging with secrets.
     """
-    logger = logging.getLogger('mylogger')
+    logger = logging.getLogger("mylogger")
     logger.setLevel(logging.DEBUG)
     handler = logging.StreamHandler()
     handler.setFormatter(
-        MaskerFormatter("%(asctime)s %(name)s %(levelname)s %(message)s",
-                        redact=50))
+        MaskerFormatter("%(asctime)s %(name)s %(levelname)s %(message)s", redact=50)
+    )
     logger.addHandler(handler)
 
-    logger.info('"current_key": "AIzaSOHbouG6DDa6DOcRGEgOMayAXYXcw6la3c"', extra=SKIP_MASK) # noqa
+    logger.info(
+        '"current_key": "AIzaSOHbouG6DDa6DOcRGEgOMayAXYXcw6la3c"', extra=SKIP_MASK
+    )  # noqa
     logger.info('"AKIAI44QH8DHBEXAMPLE" and then more text.')
     logger.info("Datadog access token: 'abcdef1234567890abcdef1234567890'")
     logger.info('"password": "password123"')
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/maskerlogger/utils.py
+++ b/maskerlogger/utils.py
@@ -19,8 +19,9 @@ def timeout(seconds):
             thread.start()
             thread.join(seconds)
             if thread.is_alive():
-                raise TimeoutException(
-                    f"Function call exceeded {seconds} seconds")
+                raise TimeoutException(f"Function call exceeded {seconds} seconds")
             return result[0]
+
         return wrapper
+
     return decorator

--- a/tests/test_masked_logger.py
+++ b/tests/test_masked_logger.py
@@ -5,6 +5,53 @@ from io import StringIO
 from maskerlogger import MaskerFormatter, MaskerFormatterJson
 
 
+ELASTIC_PW = "^_h6yCZKuadboPDfSa7pmN2tdWPCbZPWq!!"
+MASKED_ELASTIC_PW = len(ELASTIC_PW) * "*"
+API_TOKEN = "dqu0oJU45UMbrhJ1eNfVdSQ9Yf6wj6u@!^_"
+MASKED_API_TOKEN = len(API_TOKEN) * "*"
+GCP_API_KEY = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567"
+MASKED_GCP_API_KEY = len(GCP_API_KEY) * "*"
+
+SENSITIVE_STRING = json.dumps(
+    {
+        "ELASTIC_SEARCH": {
+            "URL": "https://example.com:9200",
+            "USERNAME": "<superUserForElastic>",
+            "PASSWORD": ELASTIC_PW,
+        },
+        "ANOTHER_ELASTIC_SEARCH": {
+            "URL": "https://example.com:9200",
+            "USERNAME": "<superUserForElastic>",
+            "PASSWORD": ELASTIC_PW,
+        },
+        "API": {
+            "HOST": "https://api.example.com",
+            "USERNAME": "<api_userName>",
+            "TOKEN": API_TOKEN,
+        },
+        "GCP": {
+            "PROJECT_ID": "my-gcp-project",
+            "SERVICE_ACCOUNT": "my-service",
+            "API_KEY": GCP_API_KEY,
+        },
+    }
+)
+
+
+def common_assertions(log_output: str) -> None:
+    # ElASTIC_SEARCH password should be masked
+    assert ELASTIC_PW not in log_output
+    assert f'"PASSWORD": "{MASKED_ELASTIC_PW}"' in log_output
+
+    # API token should be masked
+    assert API_TOKEN not in log_output
+    assert f'"TOKEN": "{MASKED_API_TOKEN}"' in log_output
+
+    # GCP API key should be masked
+    assert GCP_API_KEY not in log_output
+    assert f'"API_KEY": "{MASKED_GCP_API_KEY}"' in log_output
+
+
 @pytest.fixture
 def logger_and_log_stream():
     """
@@ -13,7 +60,7 @@ def logger_and_log_stream():
     Returns:
         tuple: A logger instance and a StringIO object to capture the log output.
     """
-    logger = logging.getLogger('test_logger')
+    logger = logging.getLogger("test_logger")
     logger.setLevel(logging.DEBUG)
     logger.handlers.clear()
     log_stream = StringIO()
@@ -45,14 +92,12 @@ def test_masked_logger_text(logger_and_log_stream, log_format):
     logger.handlers[0].setFormatter(formatter)
 
     # Log a sensitive message
-    logger.info("User login with password=secretpassword")
+    logger.info(SENSITIVE_STRING)
 
     # Read and parse the log output
     log_output = log_stream.getvalue().strip()
 
-    # Validate that the password is masked in the text log output
-    assert "password=*****" in log_output
-    assert "secretpassword" not in log_output
+    common_assertions(log_output)
 
 
 def test_masked_logger_json(logger_and_log_stream, log_format):
@@ -70,15 +115,14 @@ def test_masked_logger_json(logger_and_log_stream, log_format):
     logger.handlers[0].setFormatter(formatter)
 
     # Log a sensitive message
-    logger.info("User login with password=secretpassword")
+    logger.info(SENSITIVE_STRING)
 
     # Read and parse the log output
     log_output = log_stream.getvalue().strip()
     log_json = json.loads(log_output)  # Parse the JSON log output
 
     # Validate that the password is masked in the JSON log output
-    assert "password=*****" in log_json["message"]
-    assert "secretpassword" not in log_json["message"]
+    common_assertions(log_json["message"])
 
 
 def test_masked_logger_text_format_after_masking(logger_and_log_stream, log_format):
@@ -96,14 +140,13 @@ def test_masked_logger_text_format_after_masking(logger_and_log_stream, log_form
     logger.handlers[0].setFormatter(formatter)
 
     # Log a sensitive message
-    logger.info("Sensitive data: password=secretpassword and other info")
+    logger.info(SENSITIVE_STRING)
 
     # Read and parse the log output
     log_output = log_stream.getvalue().strip()
 
     # Validate that the password is masked and the log format is correct
-    assert "password=*****" in log_output
-    assert "secretpassword" not in log_output
+    common_assertions(log_output)
 
 
 def test_masked_logger_json_format_after_masking(logger_and_log_stream, log_format):
@@ -122,15 +165,14 @@ def test_masked_logger_json_format_after_masking(logger_and_log_stream, log_form
     logger.handlers[0].setFormatter(formatter)
 
     # Log a sensitive message
-    logger.info("Sensitive data: password=secretpassword and other info")
+    logger.info(SENSITIVE_STRING)
 
     # Read and parse the log output
     log_output = log_stream.getvalue().strip()
     log_json = json.loads(log_output)  # Parse the JSON log output
 
     # Validate that the password is masked and the JSON log format is correct
-    assert "password=*****" in log_json["message"]
-    assert "secretpassword" not in log_json["message"]
+    common_assertions(log_json["message"])
 
 
 def test_masked_logger_non_sensitive_data(logger_and_log_stream, log_format):


### PR DESCRIPTION
## Main change
- Allows to catch more than 1 leak in same string. Before only the first instance was being catch, and tests were also looking at this case. Tests were updated to cover these more complex cases.

Example:
```python
from maskerlogger import mask_string
my_str="This is some confidential line, and the user password: mysuperSecretPassword and btw the user apiKey=AIzaSyabcdefghijklmnopqrstuvwxyz1234567"
# Output:
# This is some confidential line, and the user password: ********************* and btw the user apiKey=***************************************
# Before this change only the password would have been masked and not the ApiKey :(
```

- Removes the main masking logic from `AbstractMaskedLogger` and instead logic is placed into a independent function `mask_string`. This allow + flexible usage of the codebase. For example, in my use case I want to have access to this function to cleanup a string outside of logging context, but since logic is currently hidden inside `AbstractMaskedLogger._mask_sensitive_data` and the argument is a `LogRecord` we cannot use this logic for more generic cases. By abstracting away the logic to an independent `mask_string` method we can use this code base into other use-cases. Retro-compatibility is ensured by calling `mask_string` inside `AbstractMaskedLogger._mask_sensitive_data`.

Example use case:

```python
from maskerlogger import mask_string
my_str= "Here I have a generic string with a potential leak. Password: mypasswordoops"
masked_my_str=mask_string(my_str)
# Done! My str was cleaned into a context that is not related to logging at all. Awesome library :) 
```

## Additional
- Performs general code cleanup (more pythonic code, better type hints, code formatting, etc)
- Changes the rule `generic-api-key` to allow common chars that are used in passwords/api keys, and reduce minimum length to 8 instead of 10, as it's very common for passwords to have 8 as required minimum chars

 