### PR TITLE
Ease constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "maskerlogger"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 description = "mask your secrets from your logs"
 authors = ["Tamar Galer <tamar@ox.security>"]
 readme = "README.md"
@@ -10,7 +10,7 @@ packages = [{include = "maskerlogger"}]
 python = ">=3.8"
 pyahocorasick = "^2.1.0"
 python-json-logger = "^2.0.7"
-tomli = "^2.1.1"
+tomli = ">=2.0.0,<3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
more range of allowed versions for tomli lib

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps package version and broadens `tomli` dependency range to `>=2.0.0,<3.0.0`.
> 
> - **pyproject.toml**:
>   - **Version**: Update `version` to `0.4.0-beta.2`.
>   - **Dependencies**: Broaden `tomli` constraint from `^2.1.1` to `>=2.0.0,<3.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d11470d1bd8c34f26899343254e5e7a94e72e48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->