### PR TITLE
masker_formatter: Allow catching multiple secrets in the same str

### DIFF
--- a/maskerlogger/ahocorasick_regex_match.py
+++ b/maskerlogger/ahocorasick_regex_match.py
@@ -101,8 +101,7 @@ class RegexMatcher:
     ) -> list[re.Match[str]]:
         matches: list[re.Match[str]] = []
         for regex in matched_regex:
-            if match := regex.search(line):
-                matches.append(match)
+            matches.extend(regex.finditer(line))
         return matches
 
     def match_regex_to_line(self, line: str) -> list[re.Match[str]] | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maskerlogger"
-version = "1.1.0b1"
+version = "1.1.0b2"
 description = "mask your secrets from your logs"
 authors = [
     {name = "Tamar Galer", email = "tamar@ox.security"},

--- a/tests/test_masked_logger.py
+++ b/tests/test_masked_logger.py
@@ -342,3 +342,155 @@ def test_masked_logger_empty_capture_groups(logger_and_log_stream, log_format):
     assert "AKIAIOSFODNN7EXAMPLE" not in log_output
     # Some part of the message should be masked (asterisks should appear)
     assert "*" in log_output
+
+
+def test_masked_logger_no_capture_groups_fallback(logger_and_log_stream, log_format):
+    """
+    Test that patterns with no capture groups fall back to masking the entire match (group 0).
+    This covers the fallback code path when masked_something remains False.
+    """
+    logger, log_stream = logger_and_log_stream
+
+    # Set the MaskerFormatter formatter
+    formatter = MaskerFormatter(fmt=log_format)
+    logger.handlers[0].setFormatter(formatter)
+
+    # Use a pattern that we know doesn't have capture groups but matches secrets
+    # The JWT pattern should match without capture groups in some cases
+    logger.info(
+        "JWT: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+
+    log_output = log_stream.getvalue().strip()
+
+    # The entire JWT should be masked since there are no capture groups
+    assert "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" not in log_output
+    assert "*" in log_output
+
+
+def test_masked_logger_all_capture_groups_none(logger_and_log_stream, log_format):
+    """
+    Test the fallback to group 0 when all capture groups are None.
+    This specifically tests the case where match.groups() returns a tuple with None values.
+    """
+    import re
+    from unittest.mock import Mock
+
+    logger, log_stream = logger_and_log_stream
+
+    formatter = MaskerFormatter(fmt=log_format)
+
+    # Mock a match object that has capture groups but they're all None
+    mock_match = Mock(spec=re.Match)
+    mock_match.groups.return_value = (None, None)  # Two capture groups, both None
+    mock_match.group.side_effect = lambda i=0: "sensitivedata12345" if i == 0 else None
+    mock_match.start.side_effect = lambda i=0: 10 if i == 0 else -1
+    mock_match.end.side_effect = lambda i=0: 27 if i == 0 else -1
+
+    # Test the _mask_secret method directly with our mock match
+    test_message = "Some text sensitivedata12345 more text"
+    result = formatter._mask_secret(test_message, [mock_match])
+
+    # Should fall back to masking the entire match since all capture groups are None
+    assert "sensitivedata12345" not in result
+    assert "*" in result
+
+
+def test_masked_logger_all_capture_groups_empty(logger_and_log_stream, log_format):
+    """
+    Test the fallback to group 0 when all capture groups are empty strings.
+    """
+    import re
+    from unittest.mock import Mock
+
+    logger, log_stream = logger_and_log_stream
+
+    formatter = MaskerFormatter(fmt=log_format)
+
+    # Mock a match object that has capture groups, but they're all empty strings
+    mock_match = Mock(spec=re.Match)
+    mock_match.groups.return_value = ("", "")  # Two capture groups, both empty
+    mock_match.group.side_effect = lambda i=0: "anothersecret123" if i == 0 else ""
+    mock_match.start.side_effect = lambda i=0: 5 if i == 0 else -1
+    mock_match.end.side_effect = lambda i=0: 21 if i == 0 else -1
+
+    # Test the _mask_secret method directly
+    test_message = "Data anothersecret123 end"
+    result = formatter._mask_secret(test_message, [mock_match])
+
+    # Should fall back to masking the entire match since all capture groups are empty
+    assert "anothersecret123" not in result
+    assert "*" in result
+
+
+def test_masked_logger_fallback_with_different_redact_percentages():
+    """
+    Test the fallback masking with different redact percentages to ensure
+    the redact_length calculation works correctly in the fallback code path.
+    """
+    import re
+    from unittest.mock import Mock
+
+    test_cases = [
+        (0, "testsecret1234", "testsecret1234"),  # 0% should not mask anything
+        (50, "testsecret1234", "*******cret1234"),  # 50% should mask half
+        (100, "testsecret1234", "**************"),  # 100% should mask everything
+    ]
+
+    for redact_percent, secret, _ in test_cases:
+        formatter = MaskerFormatter(fmt="%(message)s", redact=redact_percent)
+
+        # Mock a match with no valid capture groups
+        mock_match = Mock(spec=re.Match)
+        mock_match.groups.return_value = (None,)
+        mock_match.group.side_effect = lambda i=0, s=secret: s if i == 0 else None
+        mock_match.start.side_effect = lambda i=0: 0 if i == 0 else -1
+        mock_match.end.side_effect = lambda i=0, s=secret: len(s) if i == 0 else -1
+
+        result = formatter._mask_secret(secret, [mock_match])
+
+        if redact_percent == 0:
+            # 0% redaction should leave the original text
+            assert result == secret
+        else:
+            # Other percentages should mask appropriately
+            expected_mask_length = int((len(secret) / 100) * redact_percent)
+            expected_asterisks = "*" * expected_mask_length
+            expected_remaining = secret[expected_mask_length:]
+            expected_result = expected_asterisks + expected_remaining
+            assert result == expected_result, (
+                f"Redact {redact_percent}%: expected {expected_result}, got {result}"
+            )
+
+
+def test_masked_logger_mixed_capture_groups_fallback():
+    """
+    Test a scenario where some matches have valid capture groups and others need fallback.
+    This ensures both code paths work together correctly.
+    """
+    import re
+    from unittest.mock import Mock
+
+    formatter = MaskerFormatter(fmt="%(message)s")
+
+    # First match: has a valid capture group
+    mock_match1 = Mock(spec=re.Match)
+    mock_match1.groups.return_value = ("validgroup123",)
+    mock_match1.group.side_effect = lambda i=0: "key=validgroup123" if i == 0 else "validgroup123"
+    mock_match1.start.side_effect = lambda i=0: 0 if i == 0 else 4
+    mock_match1.end.side_effect = lambda i=0: 17 if i == 0 else 17
+
+    # Second match: has capture groups, but they're all None (needs fallback)
+    mock_match2 = Mock(spec=re.Match)
+    mock_match2.groups.return_value = (None, None)
+    mock_match2.group.side_effect = lambda i=0: "fallbacksecret" if i == 0 else None
+    mock_match2.start.side_effect = lambda i=0: 20 if i == 0 else -1
+    mock_match2.end.side_effect = lambda i=0: 34 if i == 0 else -1
+
+    test_message = "key=validgroup123 : fallbacksecret end"
+    result = formatter._mask_secret(test_message, [mock_match1, mock_match2])
+
+    # Both secrets should be masked
+    assert "validgroup123" not in result
+    assert "fallbacksecret" not in result
+    assert "*" in result


### PR DESCRIPTION
## Description  
Fixed a critical issue where only the first occurrence of a secret pattern was being detected and masked in log messages. The MaskerLogger now properly detects and masks all instances of secrets within the same string, significantly improving security coverage.

## Related Issue  
Fixes # (if there's an associated issue number)

## Type of Change  
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements

## Changes Made  
- **Fixed regex matching in `ahocorasick_regex_match.py`**: Changed from `regex.search()` to `regex.finditer()` to find all occurrences of each pattern in a line, not just the first one
- **Completely rewrote `_mask_secret()` method in `masker_formatter.py`**: Replaced the problematic string replacement approach with a position-based masking system that:
  - Handles multiple occurrences of the same secret correctly
  - Processes both grouped and non-grouped regex matches
  - Applies replacements from right to left to preserve match positions
  - Avoids issues with overlapping or similar matches
- **Added comprehensive tests**: Created two new test cases to verify multiple leak detection works for both identical and different secret types

## Testing  
- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Tested manually (describe below)

### Manual Testing Steps  
1. Created log messages with multiple instances of the same password: `"First password=secretpassword and second password=anothersecret and third password=secretpassword"`
2. Verified that all three password instances are now properly masked
3. Tested with multiple different secret types in the same string to ensure comprehensive coverage
4. Confirmed that existing single-secret masking functionality remains unaffected

## Checklist  
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added/updated docstrings for all functions and classes
- [x] I have added type annotations to all functions and classes
- [x] My changes generate no new linting errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)  
**Before Fix:**
```
First password=secretpassword and second password=anothersecret and third password=secretpassword
# Only first instance would be masked
```

**After Fix:**
```
First password=************** and second password=************* and third password=**************
# All instances are now properly masked
```

## Additional Context  
This fix addresses a significant security vulnerability where sensitive data could leak through logs if the same secret appeared multiple times in a single log message. The previous implementation used `msg.replace(group, masked_part, 1)` which explicitly limited replacement to only the first occurrence.

The new implementation:
1. Uses `finditer()` to find all regex matches in the text
2. Collects all match positions and their replacements
3. Applies masking from right to left to avoid position shifting
4. Properly handles both regex groups and full matches

This ensures comprehensive secret detection and masking while maintaining backward compatibility with existing functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch to find-all regex matching and a position-based masking algorithm to mask multiple/overlapping secrets, with extensive tests; bump version to 1.1.0b2.
> 
> - **Masking engine**:
>   - Use `regex.finditer()` in `maskerlogger/ahocorasick_regex_match.py` to collect all matches per pattern.
>   - Rewrite `_mask_secret` in `maskerlogger/masker_formatter.py` to a position-based masker that:
>     - Masks multiple occurrences and overlapping spans.
>     - Prefers capture groups; falls back to full match when groups are empty/None or absent.
>     - Honors configurable redact percentage across groups and full matches.
> - **Tests** (`tests/test_masked_logger.py`):
>   - Add cases for multiple identical secrets, multiple different secrets, overlapping matches, empty/None capture groups, no-capture fallback, mixed paths, and varying redact percentages.
> - **Version**: bump `pyproject.toml` to `1.1.0b2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d73052e2c600ba1266d1a9c714d203b7a8789dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->