### PR TITLE
Masked the exc_info output in exception log tracebacks

### DIFF
--- a/maskerlogger/masker_formatter.py
+++ b/maskerlogger/masker_formatter.py
@@ -108,10 +108,25 @@ class AbstractMaskedLogger(ABC):  # noqa B024
         return "".join(result)
 
     def _mask_sensitive_data(self, record: logging.LogRecord) -> None:
-        """Applies masking to the sensitive data in the log message."""
+        """Applies masking to the sensitive data in the log message and traceback."""
         try:
-            if found_matching_regex := self.regex_matcher.match_regex_to_line(record.msg):  # noqa
+            # Mask the main log message
+            if found_matching_regex := self.regex_matcher.match_regex_to_line(record.msg):
                 record.msg = self._mask_secret(record.msg, found_matching_regex)
+
+            # Mask exc_text if present
+            if hasattr(record, 'exc_text') and record.exc_text:
+                if found_matching_regex := self.regex_matcher.match_regex_to_line(record.exc_text):
+                    record.exc_text = self._mask_secret(record.exc_text, found_matching_regex)
+
+            # Mask exc_info (traceback) if present and exc_text not present
+            elif hasattr(record, 'exc_info') and record.exc_info:
+                import traceback
+                exc_type, exc_value, exc_tb = record.exc_info
+                tb_str = ''.join(traceback.format_exception(exc_type, exc_value, exc_tb))
+                if found_matching_regex := self.regex_matcher.match_regex_to_line(tb_str):
+                    masked_tb_str = self._mask_secret(tb_str, found_matching_regex)
+                    record.exc_text = masked_tb_str  # exc_text is used by logging.Formatter
         except TimeoutException:
             pass
 
@@ -170,3 +185,11 @@ class MaskerFormatterJson(jsonlogger.JsonFormatter, AbstractMaskedLogger):
             self._mask_sensitive_data(record)
 
         return str(super().format(record))
+
+    def formatException(self, exc_info):
+        # Get the formatted exception string from the base class
+        formatted = super().formatException(exc_info)
+        # Mask sensitive data in the formatted exception string
+        if found_matching_regex := self.regex_matcher.match_regex_to_line(formatted):
+            return self._mask_secret(formatted, found_matching_regex)
+        return formatted


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements

## Changes Made

<!-- List the main changes in bullet points -->

-
-
-

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] All existing tests pass
- [ ] Added new tests for the changes
- [ ] Tested manually (describe below)

### Manual Testing Steps

<!-- If applicable, describe manual testing steps -->

1.
2.
3.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added/updated docstrings for all functions and classes
- [ ] I have added type annotations to all functions and classes
- [ ] My changes generate no new linting errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Context

<!-- Add any other context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Masks sensitive data in exception tracebacks and formatted exceptions for both text and JSON loggers, with tests added.
> 
> - **Logging/Masking**:
>   - Enhance `AbstractMaskedLogger._mask_sensitive_data` to mask `record.msg`, `record.exc_text`, and formatted `exc_info` (traceback) when present.
>   - Override `MaskerFormatterJson.formatException` to mask sensitive data in formatted exceptions.
> - **Tests**:
>   - Add tests to verify masking in traceback for text logs and JSON logs (`exc_info` field).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fec1dab0aac6944358a9bde5adc1b46a12fd64d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->