### PR TITLE
Masked the exc_info output in exception log tracebacks

### DIFF
--- a/maskerlogger/__init__.py
+++ b/maskerlogger/__init__.py
@@ -4,4 +4,4 @@ Init file for maskerlogger package.
 
 from maskerlogger.masker_formatter import MaskerFormatter, MaskerFormatterJson, SKIP_MASK  # noqa
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/maskerlogger/masker_formatter.py
+++ b/maskerlogger/masker_formatter.py
@@ -108,10 +108,25 @@ class AbstractMaskedLogger(ABC):  # noqa B024
         return "".join(result)
 
     def _mask_sensitive_data(self, record: logging.LogRecord) -> None:
-        """Applies masking to the sensitive data in the log message."""
+        """Applies masking to the sensitive data in the log message and traceback."""
         try:
-            if found_matching_regex := self.regex_matcher.match_regex_to_line(record.msg):  # noqa
+            # Mask the main log message
+            if found_matching_regex := self.regex_matcher.match_regex_to_line(record.msg):
                 record.msg = self._mask_secret(record.msg, found_matching_regex)
+
+            # Mask exc_text if present
+            if hasattr(record, 'exc_text') and record.exc_text:
+                if found_matching_regex := self.regex_matcher.match_regex_to_line(record.exc_text):
+                    record.exc_text = self._mask_secret(record.exc_text, found_matching_regex)
+
+            # Mask exc_info (traceback) if present and exc_text not present
+            elif hasattr(record, 'exc_info') and record.exc_info:
+                import traceback
+                exc_type, exc_value, exc_tb = record.exc_info
+                tb_str = ''.join(traceback.format_exception(exc_type, exc_value, exc_tb))
+                if found_matching_regex := self.regex_matcher.match_regex_to_line(tb_str):
+                    masked_tb_str = self._mask_secret(tb_str, found_matching_regex)
+                    record.exc_text = masked_tb_str  # exc_text is used by logging.Formatter
         except TimeoutException:
             pass
 
@@ -170,3 +185,11 @@ class MaskerFormatterJson(jsonlogger.JsonFormatter, AbstractMaskedLogger):
             self._mask_sensitive_data(record)
 
         return str(super().format(record))
+
+    def formatException(self, exc_info):
+        # Get the formatted exception string from the base class
+        formatted = super().formatException(exc_info)
+        # Mask sensitive data in the formatted exception string
+        if found_matching_regex := self.regex_matcher.match_regex_to_line(formatted):
+            return self._mask_secret(formatted, found_matching_regex)
+        return formatted

--- a/maskerlogger/masker_formatter.py
+++ b/maskerlogger/masker_formatter.py
@@ -108,13 +108,28 @@ class AbstractMaskedLogger(ABC):  # noqa B024
         return "".join(result)
 
     def _mask_sensitive_data(self, record: logging.LogRecord) -> None:
-        """Applies masking to the sensitive data in the log message."""
+        """Applies masking to the sensitive data in the log message and traceback."""
         try:
-            if found_matching_regex := self.regex_matcher.match_regex_to_line(record.msg):  # noqa
+            # Mask the main log message
+            if found_matching_regex := self.regex_matcher.match_regex_to_line(record.msg):
                 record.msg = self._mask_secret(record.msg, found_matching_regex)
 
+            # Mask exc_text if present
+            if hasattr(record, 'exc_text') and record.exc_text:
+                if found_matching_regex := self.regex_matcher.match_regex_to_line(record.exc_text):
+                    record.exc_text = self._mask_secret(record.exc_text, found_matching_regex)
+
+            # Mask exc_info (traceback) if present and exc_text not present
+            elif hasattr(record, 'exc_info') and record.exc_info:
+                import traceback
+                exc_type, exc_value, exc_tb = record.exc_info
+                tb_str = ''.join(traceback.format_exception(exc_type, exc_value, exc_tb))
+                if found_matching_regex := self.regex_matcher.match_regex_to_line(tb_str):
+                    masked_tb_str = self._mask_secret(tb_str, found_matching_regex)
+                    record.exc_text = masked_tb_str  # exc_text is used by logging.Formatter
         except TimeoutException:
             pass
+
 
 # Normal Masked Logger - Text-Based Log Formatter
 class MaskerFormatter(logging.Formatter, AbstractMaskedLogger):
@@ -138,17 +153,10 @@ class MaskerFormatter(logging.Formatter, AbstractMaskedLogger):
 
     def format(self, record: logging.LogRecord) -> str:
         """Formats the log record as text and applies masking."""
-        # Format the record using the parent formatter first
-        formatted = super().format(record)
-
         if getattr(record, _APPLY_MASK, True):
-            try:
-                if found_matching_regex := self.regex_matcher.match_regex_to_line(formatted):
-                    formatted = self._mask_secret(formatted, found_matching_regex)
-            except TimeoutException:
-                pass
+            self._mask_sensitive_data(record)
 
-        return formatted
+        return super().format(record)
 
 
 # JSON Masked Logger - JSON-Based Log Formatter
@@ -173,14 +181,15 @@ class MaskerFormatterJson(jsonlogger.JsonFormatter, AbstractMaskedLogger):
 
     def format(self, record: logging.LogRecord) -> str:
         """Formats the log record as JSON and applies masking."""
-        # Format the record using the parent formatter first
-        formatted = str(super().format(record))
-
         if getattr(record, _APPLY_MASK, True):
-            try:
-                if found_matching_regex := self.regex_matcher.match_regex_to_line(formatted):
-                    formatted = self._mask_secret(formatted, found_matching_regex)
-            except TimeoutException:
-                pass
+            self._mask_sensitive_data(record)
 
+        return str(super().format(record))
+
+    def formatException(self, exc_info):
+        # Get the formatted exception string from the base class
+        formatted = super().formatException(exc_info)
+        # Mask sensitive data in the formatted exception string
+        if found_matching_regex := self.regex_matcher.match_regex_to_line(formatted):
+            return self._mask_secret(formatted, found_matching_regex)
         return formatted

--- a/maskerlogger/masker_formatter.py
+++ b/maskerlogger/masker_formatter.py
@@ -115,15 +115,16 @@ class AbstractMaskedLogger(ABC):  # noqa B024
                 record.msg = self._mask_secret(record.msg, found_matching_regex)
 
             # Mask exc_text if present
-            if hasattr(record, 'exc_text') and record.exc_text:
+            if hasattr(record, "exc_text") and record.exc_text:
                 if found_matching_regex := self.regex_matcher.match_regex_to_line(record.exc_text):
                     record.exc_text = self._mask_secret(record.exc_text, found_matching_regex)
 
             # Mask exc_info (traceback) if present and exc_text not present
-            elif hasattr(record, 'exc_info') and record.exc_info:
+            elif hasattr(record, "exc_info") and record.exc_info:
                 import traceback
+
                 exc_type, exc_value, exc_tb = record.exc_info
-                tb_str = ''.join(traceback.format_exception(exc_type, exc_value, exc_tb))
+                tb_str = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
                 if found_matching_regex := self.regex_matcher.match_regex_to_line(tb_str):
                     masked_tb_str = self._mask_secret(tb_str, found_matching_regex)
                     record.exc_text = masked_tb_str  # exc_text is used by logging.Formatter
@@ -186,10 +187,10 @@ class MaskerFormatterJson(jsonlogger.JsonFormatter, AbstractMaskedLogger):
 
         return str(super().format(record))
 
-    def formatException(self, exc_info):
+    def formatException(self, exc_info: tuple[type, BaseException, object]) -> str:
         # Get the formatted exception string from the base class
         formatted = super().formatException(exc_info)
         # Mask sensitive data in the formatted exception string
         if found_matching_regex := self.regex_matcher.match_regex_to_line(formatted):
             return self._mask_secret(formatted, found_matching_regex)
-        return formatted
+        return str(formatted)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maskerlogger"
-version = "1.1.0"
+version = "1.1.1"
 description = "mask your secrets from your logs"
 authors = [
     {name = "Tamar Galer", email = "tamar@ox.security"},

--- a/tests/test_masked_logger.py
+++ b/tests/test_masked_logger.py
@@ -512,7 +512,7 @@ def test_masked_logger_masks_secrets_in_traceback_text(logger_and_log_stream, lo
 
     log_output = log_stream.getvalue()
     # The secret should be masked in the traceback
-    assert f"password=" in log_output
+    assert "password=" in log_output
     assert secret not in log_output
     assert "*****" in log_output
 
@@ -534,6 +534,6 @@ def test_masked_logger_masks_secrets_in_traceback_json(logger_and_log_stream, lo
     log_output = log_stream.getvalue()
     log_json = json.loads(log_output)
     # The secret should be masked in the traceback (exc_info field)
-    assert f"password=" in log_json.get("exc_info", "")
+    assert "password=" in log_json.get("exc_info", "")
     assert secret not in log_json.get("exc_info", "")
     assert "*****" in log_json.get("exc_info", "")


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements

## Changes Made

<!-- List the main changes in bullet points -->

-
-
-

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] All existing tests pass
- [ ] Added new tests for the changes
- [ ] Tested manually (describe below)

### Manual Testing Steps

<!-- If applicable, describe manual testing steps -->

1.
2.
3.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added/updated docstrings for all functions and classes
- [ ] I have added type annotations to all functions and classes
- [ ] My changes generate no new linting errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Context

<!-- Add any other context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Masks sensitive data in exception tracebacks for both text and JSON formatters, adds tests, and bumps version to 1.1.1.
> 
> - **Logging/Masking**:
>   - Enhance `AbstractMaskedLogger._mask_sensitive_data` to mask `record.msg`, `record.exc_text`, and fallback to masking `exc_info` (traceback) by populating `record.exc_text`.
>   - Override `MaskerFormatterJson.formatException` to mask secrets in serialized exceptions.
> - **Tests**:
>   - Add tests to ensure traceback masking in text (`MaskerFormatter`) and JSON (`MaskerFormatterJson`) outputs.
> - **Version**:
>   - Bump version to `1.1.1` in `maskerlogger/__init__.py` and `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98e4f224deaca4423b47e343114fc15363efa2fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->